### PR TITLE
Ignore markdown files in CI workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,8 +6,12 @@ name: Python package
 on:
   push:
     branches: [ "master" ]
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches: [ "master" ]
+    paths-ignore:
+      - "**.md"
 
 jobs:
   build:


### PR DESCRIPTION
Updated the GitHub Actions workflow config to ignore changes in markdown files. This change will prevent unnecessary CI runs when only documentation is updated, thus saving resources and run time.